### PR TITLE
v10 compat: Fix registerBatch throwing an error

### DIFF
--- a/src/module/quench.ts
+++ b/src/module/quench.ts
@@ -97,9 +97,7 @@ export class Quench {
   ): void {
     const { displayName, snapBaseDir, preSelected } = context;
     const [packageName] = getBatchNameParts(key);
-    if (
-      ![...getGame().modules, [getGame().system.id]].map(([pName]) => pName).includes(packageName)
-    ) {
+    if (![...getGame().modules.keys(), getGame().system.id].includes(packageName)) {
       ui?.notifications?.error(localize("ERROR.InvalidPackageName", { key, packageName }));
     }
     if (this._testBatches.has(key)) {


### PR DESCRIPTION
- behavior of spreading game.modules changed to return values instead of entries
- using game.modules.keys() resolves the issue